### PR TITLE
build(deps-dev): bump typescript from 4.5.2 to 4.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "plop": "^3.0.2",
     "prettier": "^2.5.1",
     "storybook-dark-mode": "^1.0.8",
-    "typescript": "4.5.2"
+    "typescript": "4.5.4"
   },
   "resolutions": {
     "webpack": "5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12800,12 +12800,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
-  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
-
-typescript@^4.4.3:
+typescript@4.5.4, typescript@^4.4.3:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
   integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==


### PR DESCRIPTION
## PR: Dependencies update

**Summary**
Updates to [Typescript 4.5.4](https://github.com/microsoft/TypeScript/releases/tag/v4.5.4)

**Checklist**

- [x] The commit's or even all commits' message styles matches the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specifications
- [x] The changes don't break any existing tests
