### PR TITLE
build(deps): add missing peer dependency for styled-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "next": "12.0.7",
     "react": "17.0.2",
     "react-dom": "17.0.2",
+    "react-is": "^17.0.2",
     "styled-components": "^5.3.3",
     "styled-media-query": "^2.1.2"
   },


### PR DESCRIPTION
## PR: Dependencies update

**Summary**
Adds `react-is` due to `styled-components` missing peer dependency warning.

**Checklist**

- [x] The commit's or even all commits' message styles matches the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specifications
- [x] The changes don't break any existing tests
