### PR TITLE
fix: add missing ghost button styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "typecheck": "tsc --project tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@styled-icons/bootstrap": "^10.34.0",
     "formik": "^2.2.9",
     "next": "12.0.7",
     "react": "17.0.2",

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,4 +1,6 @@
 import { AnchorHTMLAttributes, ButtonHTMLAttributes } from 'react'
+import { ArrowRightCircleFill as Icon } from '@styled-icons/bootstrap'
+
 import * as S from './styles'
 
 export type ButtonTypes =
@@ -8,12 +10,19 @@ export type ButtonTypes =
 export type ButtonProps = {
   as?: React.ElementType
   disabled?: boolean
+  ghost?: boolean
 } & ButtonTypes
 
-export function Button({ children, disabled = false, ...rest }: ButtonProps) {
+export function Button({
+  children,
+  disabled = false,
+  ghost = false,
+  ...rest
+}: ButtonProps) {
   return (
-    <S.Container disabled={disabled} {...rest}>
+    <S.Container disabled={disabled} ghost={ghost} {...rest}>
       {children}
+      {ghost && <span data-testid="icon">{<Icon size={12} />}</span>}
     </S.Container>
   )
 }

--- a/src/components/Button/stories.tsx
+++ b/src/components/Button/stories.tsx
@@ -9,8 +9,13 @@ export default {
     children: {
       type: 'string'
     },
-    control: {
-      disabled: {
+    disabled: {
+      control: {
+        type: 'boolean'
+      }
+    },
+    ghost: {
+      control: {
         type: 'boolean'
       }
     }
@@ -30,4 +35,13 @@ AsLink.args = {
   children: 'Link',
   as: 'a',
   href: '/link'
+}
+
+export const AsGhostLink: Story<ButtonProps> = (args) => <Button {...args} />
+
+AsGhostLink.args = {
+  children: 'Ghost link',
+  as: 'a',
+  href: '/link',
+  ghost: true
 }

--- a/src/components/Button/styles.ts
+++ b/src/components/Button/styles.ts
@@ -10,11 +10,37 @@ const Modifiers = {
       filter: saturate(0%);
       cursor: not-allowed;
     }
+  `,
+  ghost: (theme: DefaultTheme) => css`
+    width: auto;
+    padding: 0.4rem 0;
+    border-radius: 0;
+    border-bottom: 0.1rem solid ${theme.colors.cyan};
+    background: transparent;
+    color: ${theme.colors.cyan};
+    font-family: ${theme.font.family.main};
+    font-size: 1.2rem;
+    font-weight: ${theme.font.weight.normal};
+    text-transform: none;
+
+    span {
+      margin-left: ${theme.spacings.xxsmall};
+    }
+
+    &:hover {
+      border-bottom-color: ${theme.colors.white};
+      color: ${theme.colors.white};
+    }
+
+    ${media.greaterThan('large')`
+      padding: 0.4rem 0;
+      font-size: 1.4rem;
+    `}
   `
 }
 
 export const Container = styled.button<ButtonProps>`
-  ${({ theme, disabled }) => css`
+  ${({ theme, disabled, ghost }) => css`
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -52,5 +78,7 @@ export const Container = styled.button<ButtonProps>`
       max-width: 28rem;
       font-size: 1.6rem;
     `}
+
+    ${ghost && Modifiers.ghost(theme)}
   `}
 `

--- a/src/components/Button/test.tsx
+++ b/src/components/Button/test.tsx
@@ -27,4 +27,19 @@ describe('<Button />', () => {
     expect(button).toBeInTheDocument()
     expect(button).toHaveAttribute('href', '/link')
   })
+
+  it('renders the button as a ghost link with an icon correctly', () => {
+    render(
+      <Button as="a" href="/link" ghost>
+        ghost link
+      </Button>
+    )
+
+    const button = screen.getByRole('link', { name: /ghost link/i })
+    const icon = screen.getByTestId(/icon/i)
+
+    expect(button).toBeInTheDocument()
+    expect(button).toHaveAttribute('href', '/link')
+    expect(icon).toBeInTheDocument()
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1097,7 +1097,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.0", "@babel/runtime@^7.14.8", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.5", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.0", "@babel/runtime@^7.14.8", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.16.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.5.tgz#7f3e34bf8bdbbadf03fbb7b1ea0d929569c9487a"
   integrity sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==
@@ -1344,7 +1344,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
-"@emotion/is-prop-valid@0.8.8", "@emotion/is-prop-valid@^0.8.6", "@emotion/is-prop-valid@^0.8.8":
+"@emotion/is-prop-valid@0.8.8", "@emotion/is-prop-valid@^0.8.6", "@emotion/is-prop-valid@^0.8.7", "@emotion/is-prop-valid@^0.8.8":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
   integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
@@ -2860,6 +2860,22 @@
     regenerator-runtime "^0.13.7"
     resolve-from "^5.0.0"
     store2 "^2.12.0"
+
+"@styled-icons/bootstrap@^10.34.0":
+  version "10.34.0"
+  resolved "https://registry.yarnpkg.com/@styled-icons/bootstrap/-/bootstrap-10.34.0.tgz#d9142e9eb70dc437f7ef62ffc40168e1ae13ab12"
+  integrity sha512-UpzdVUR7r9BNqEfPrMchJdgMZEg9eXQxLQJUXM0ouvbI5o9j21/y1dGameO4PZtYbutT/dWv5O6y24z5JWzd5w==
+  dependencies:
+    "@babel/runtime" "^7.14.0"
+    "@styled-icons/styled-icon" "^10.6.3"
+
+"@styled-icons/styled-icon@^10.6.3":
+  version "10.6.3"
+  resolved "https://registry.yarnpkg.com/@styled-icons/styled-icon/-/styled-icon-10.6.3.tgz#eae0e5e18fd601ac47e821bb9c2e099810e86403"
+  integrity sha512-/A95L3peioLoWFiy+/eKRhoQ9r/oRrN/qzbSX4hXU1nGP2rUXcX3LWUhoBNAOp9Rw38ucc/4ralY427UUNtcGQ==
+  dependencies:
+    "@babel/runtime" "^7.10.5"
+    "@emotion/is-prop-valid" "^0.8.7"
 
 "@testing-library/dom@^8.0.0":
   version "8.11.1"


### PR DESCRIPTION
## PR: Bugfix

**Summary**
Adds missing `ghost` button styles.

**Checklist**

- [x] The commit's or even all commits' message styles matches the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specifications
- [x] The code follows all linting rules
- [x] Tests have been added and pass locally
